### PR TITLE
feat: conventional commits can be enforced

### DIFF
--- a/.github/workflows/conventional_commit.yaml
+++ b/.github/workflows/conventional_commit.yaml
@@ -1,0 +1,13 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
This PR lints commits according to the conventional commit standard. See https://github.com/wagoid/commitlint-github-action.
